### PR TITLE
Add improvements and fixes for benchmarks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,41 +22,34 @@ Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 or visit www.oracle.com if you need additional information or have any
 questions.
 -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <groupId>net.shipilev</groupId>
     <artifactId>disrupting-fjp</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
-
-    <name>Auto-generated JMH benchmark</name>
-
     <dependencies>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
-            <version>0.5.6</version>
+            <version>1.6.1</version>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>
-            <version>0.5.6</version>
+            <version>1.6.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.lmax</groupId>
             <artifactId>disruptor</artifactId>
-            <version>3.2.0</version>
+            <version>3.3.2</version>
         </dependency>
     </dependencies>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-
     <build>
         <plugins>
             <plugin>
@@ -90,8 +83,6 @@ questions.
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
     </build>
-
 </project>

--- a/src/main/java/net/shipilev/Disruptor.java
+++ b/src/main/java/net/shipilev/Disruptor.java
@@ -24,10 +24,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
-@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.MILLISECONDS)
-@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3)
+@Measurement(iterations = 10)
 @Fork(1)
-@BenchmarkMode(Mode.AverageTime)
+@BenchmarkMode(Mode.SingleShotTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class Disruptor {
 

--- a/src/main/java/net/shipilev/ForkJoin.java
+++ b/src/main/java/net/shipilev/ForkJoin.java
@@ -2,7 +2,7 @@ package net.shipilev;
 
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.GenerateMicroBenchmark;
+import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -16,9 +16,9 @@ import java.util.concurrent.RecursiveTask;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
-@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(5)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class ForkJoin {
@@ -28,36 +28,37 @@ public class ForkJoin {
      */
 
     static class PiForkJoinTask extends RecursiveTask<Double> {
-        private final int slices;
+        private final int from;
+        private final int to;
 
-        public PiForkJoinTask(int slices) {
-            this.slices = slices;
+        public PiForkJoinTask(final int from, final int to) {
+            this.from = from;
+            this.to = to;
         }
 
         @Override
         protected Double compute() {
-            double acc = 0D;
-            for (int s = 0; s < slices; s++) {
+            double acc = 0;
+            for (int s = from; s < to; s++) {
                 acc += Shared.calculatePi(s);
             }
             return acc;
         }
     }
 
-    @GenerateMicroBenchmark
+    @Benchmark
     public double run() throws InterruptedException {
-        List<PiForkJoinTask> tasks = new ArrayList<PiForkJoinTask>();
+        final List<PiForkJoinTask> tasks = new ArrayList<PiForkJoinTask>();
+        final int slicePerThread = Shared.SLICES / Shared.THREADS;
         for (int i = 0; i < Shared.THREADS; i++) {
-            PiForkJoinTask task = new PiForkJoinTask(Shared.SLICES / Shared.THREADS);
+            PiForkJoinTask task = new PiForkJoinTask(i * slicePerThread, (i + 1) * slicePerThread);
             task.fork();
             tasks.add(task);
         }
-
-        double acc = 0D;
+        double acc = 0;
         for (PiForkJoinTask task : tasks) {
             acc += task.join();
         }
-
         return acc;
     }
 

--- a/src/main/java/net/shipilev/ForkJoin.java
+++ b/src/main/java/net/shipilev/ForkJoin.java
@@ -16,10 +16,10 @@ import java.util.concurrent.RecursiveTask;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
-@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.MILLISECONDS)
-@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3)
+@Measurement(iterations = 10)
 @Fork(1)
-@BenchmarkMode(Mode.AverageTime)
+@BenchmarkMode(Mode.SingleShotTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class ForkJoin {
 

--- a/src/main/java/net/shipilev/ForkJoinRecursive.java
+++ b/src/main/java/net/shipilev/ForkJoinRecursive.java
@@ -2,7 +2,7 @@ package net.shipilev;
 
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.GenerateMicroBenchmark;
+import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -15,9 +15,9 @@ import java.util.concurrent.RecursiveTask;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
-@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(5)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class ForkJoinRecursive {
@@ -28,36 +28,35 @@ public class ForkJoinRecursive {
      */
 
     static class PiForkJoinTask extends RecursiveTask<Double> {
-        private final int slices;
+        private final int from;
+        private final int to;
 
-        public PiForkJoinTask(int slices) {
-            this.slices = slices;
+        public PiForkJoinTask(final int from, final int to) {
+            this.from = from;
+            this.to = to;
         }
 
         @Override
         protected Double compute() {
+            final int slices = to - from;
             if (slices < 10000) {
-                double acc = 0D;
-                for (int s = 0; s < slices; s++) {
+                double acc = 0;
+                for (int s = from; s < to; s++) {
                     acc += Shared.calculatePi(s);
                 }
                 return acc;
             }
-
-            int lslices = slices / 2;
-            int rslices = slices - lslices;
-            PiForkJoinTask t1 = new PiForkJoinTask(lslices);
-            PiForkJoinTask t2 = new PiForkJoinTask(rslices);
-
+            final int mid = from + slices / 2;
+            PiForkJoinTask t1 = new PiForkJoinTask(from, mid);
+            PiForkJoinTask t2 = new PiForkJoinTask(mid, to);
             ForkJoinTask.invokeAll(t1, t2);
-
             return t1.join() + t2.join();
         }
     }
 
-    @GenerateMicroBenchmark
+    @Benchmark
     public double run() throws InterruptedException {
-        return new PiForkJoinTask(Shared.SLICES).invoke();
+        return new PiForkJoinTask(0, Shared.SLICES).invoke();
     }
 
 }

--- a/src/main/java/net/shipilev/ForkJoinRecursive.java
+++ b/src/main/java/net/shipilev/ForkJoinRecursive.java
@@ -15,10 +15,10 @@ import java.util.concurrent.RecursiveTask;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
-@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.MILLISECONDS)
-@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3)
+@Measurement(iterations = 10)
 @Fork(1)
-@BenchmarkMode(Mode.AverageTime)
+@BenchmarkMode(Mode.SingleShotTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class ForkJoinRecursive {
 

--- a/src/main/java/net/shipilev/ForkJoinRecursiveDeep.java
+++ b/src/main/java/net/shipilev/ForkJoinRecursiveDeep.java
@@ -15,10 +15,10 @@ import java.util.concurrent.RecursiveTask;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
-@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.MILLISECONDS)
-@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3)
+@Measurement(iterations = 10)
 @Fork(1)
-@BenchmarkMode(Mode.AverageTime)
+@BenchmarkMode(Mode.SingleShotTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class ForkJoinRecursiveDeep {
 

--- a/src/main/java/net/shipilev/ForkJoinRecursiveDeep.java
+++ b/src/main/java/net/shipilev/ForkJoinRecursiveDeep.java
@@ -2,7 +2,7 @@ package net.shipilev;
 
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.GenerateMicroBenchmark;
+import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -15,9 +15,9 @@ import java.util.concurrent.RecursiveTask;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
-@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(5)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class ForkJoinRecursiveDeep {
@@ -28,36 +28,35 @@ public class ForkJoinRecursiveDeep {
      */
 
     static class PiForkJoinTask extends RecursiveTask<Double> {
-        private final int slices;
+        private final int from;
+        private final int to;
 
-        public PiForkJoinTask(int slices) {
-            this.slices = slices;
+        public PiForkJoinTask(final int from, final int to) {
+            this.from = from;
+            this.to = to;
         }
 
         @Override
         protected Double compute() {
+            final int slices = to - from;
             if (slices <= 1) {
-                double acc = 0D;
-                for (int s = 0; s < slices; s++) {
+                double acc = 0;
+                for (int s = from; s < to; s++) {
                     acc += Shared.calculatePi(s);
                 }
                 return acc;
             }
-
-            int lslices = slices / 2;
-            int rslices = slices - lslices;
-            PiForkJoinTask t1 = new PiForkJoinTask(lslices);
-            PiForkJoinTask t2 = new PiForkJoinTask(rslices);
-
+            final int mid = from + slices / 2;
+            PiForkJoinTask t1 = new PiForkJoinTask(from, mid);
+            PiForkJoinTask t2 = new PiForkJoinTask(mid, to);
             ForkJoinTask.invokeAll(t1, t2);
-
             return t1.join() + t2.join();
         }
     }
 
-    @GenerateMicroBenchmark
+    @Benchmark
     public double run() throws InterruptedException {
-        return new PiForkJoinTask(Shared.SLICES).invoke();
+        return new PiForkJoinTask(0, Shared.SLICES).invoke();
     }
 
 }

--- a/src/main/java/net/shipilev/ForkJoinReuse.java
+++ b/src/main/java/net/shipilev/ForkJoinReuse.java
@@ -2,25 +2,21 @@ package net.shipilev;
 
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.GenerateMicroBenchmark;
+import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.RecursiveTask;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
-@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(5)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class ForkJoinReuse {
@@ -39,34 +35,39 @@ public class ForkJoinReuse {
         }
     }
 
-    @GenerateMicroBenchmark
+    @Benchmark
     public double run() throws InterruptedException {
-        List<PiForkJoinTask> tasks = new ArrayList<>();
-
-        int stride = Shared.THREADS * 100;
+        final int stride = Shared.THREADS * 100;
+        final PiForkJoinTask[] tasks = new PiForkJoinTask[stride];
         for (int i = 0; i < stride; i++) {
             PiForkJoinTask task = new PiForkJoinTask();
             task.slice = i;
             task.fork();
-            tasks.add(task);
+            tasks[i] = task;
         }
-
-        double acc = 0D;
-        int s = stride;
-        while (s < Shared.SLICES) {
+        double acc = 0;
+        final int s1 = Shared.SLICES / stride;
+        for (int i = 1; i < s1; i++) {
             for (PiForkJoinTask task : tasks) {
                 acc += task.join();
                 task.reinitialize();
-                task.slice = s;
+                task.slice += stride;
                 task.fork();
             }
-            s += stride;
         }
-
         for (PiForkJoinTask task : tasks) {
             acc += task.join();
         }
-
+        final int s2 = Shared.SLICES % stride;
+        for (int i = 0; i < s2; i++) {
+            final PiForkJoinTask task = tasks[i];
+            task.reinitialize();
+            task.slice += stride;
+            task.fork();
+        }
+        for (int i = 0; i < s2; i++) {
+            acc += tasks[i].join();
+        }
         return acc;
     }
 

--- a/src/main/java/net/shipilev/ForkJoinReuse.java
+++ b/src/main/java/net/shipilev/ForkJoinReuse.java
@@ -14,10 +14,10 @@ import java.util.concurrent.RecursiveTask;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
-@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.MILLISECONDS)
-@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3)
+@Measurement(iterations = 10)
 @Fork(1)
-@BenchmarkMode(Mode.AverageTime)
+@BenchmarkMode(Mode.SingleShotTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class ForkJoinReuse {
 

--- a/src/main/java/net/shipilev/Shared.java
+++ b/src/main/java/net/shipilev/Shared.java
@@ -6,10 +6,13 @@ public class Shared {
     public static final int ITERS = 100;
     public static final int THREADS = Runtime.getRuntime().availableProcessors();
 
-    public static double calculatePi(int sliceNr) {
-        double acc = 0.0;
-        for (int i = sliceNr * ITERS; i <= ((sliceNr + 1) * ITERS - 1); i++) {
-            acc += 4.0 * (1 - (i % 2) * 2) / (2 * i + 1);
+    public static double calculatePi(final int sliceNr) {
+        final int from = sliceNr * ITERS;
+        final int to = from + ITERS;
+        final int c = (to << 1) + 1;
+        double acc = 0;
+        for (int a = 4 - ((from & 1) << 3), b = (from << 1) + 1; b < c; a = -a, b += 2) {
+            acc += ((double) a) / b;
         }
         return acc;
     }

--- a/src/main/java/net/shipilev/SingleThread.java
+++ b/src/main/java/net/shipilev/SingleThread.java
@@ -4,10 +4,10 @@ import org.openjdk.jmh.annotations.*;
 
 import java.util.concurrent.TimeUnit;
 
-@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.MILLISECONDS)
-@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3)
+@Measurement(iterations = 10)
 @Fork(1)
-@BenchmarkMode(Mode.AverageTime)
+@BenchmarkMode(Mode.SingleShotTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class SingleThread {
 

--- a/src/main/java/net/shipilev/SingleThread.java
+++ b/src/main/java/net/shipilev/SingleThread.java
@@ -1,0 +1,23 @@
+package net.shipilev;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class SingleThread {
+
+    @Benchmark
+    public double run() {
+        double acc = 0;
+        for (int s = 0; s < Shared.SLICES; s++) {
+            acc += Shared.calculatePi(s);
+        }
+        return acc;
+    }
+
+}

--- a/src/main/java/net/shipilev/Streams.java
+++ b/src/main/java/net/shipilev/Streams.java
@@ -11,10 +11,10 @@ import org.openjdk.jmh.annotations.Warmup;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
-@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.MILLISECONDS)
-@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3)
+@Measurement(iterations = 10)
 @Fork(1)
-@BenchmarkMode(Mode.AverageTime)
+@BenchmarkMode(Mode.SingleShotTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class Streams {
 

--- a/src/main/java/net/shipilev/Streams.java
+++ b/src/main/java/net/shipilev/Streams.java
@@ -2,30 +2,28 @@ package net.shipilev;
 
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.GenerateMicroBenchmark;
+import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
-@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(5)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class Streams {
 
-    @GenerateMicroBenchmark
+    @Benchmark
     public double run() {
         return IntStream.range(0, Shared.SLICES)
                     .parallel()
                     .mapToDouble(Shared::calculatePi)
-                    .reduce(0.0, Double::sum);
+                    .reduce(0, Double::sum);
     }
 
 }


### PR DESCRIPTION
- upgrade to latest versions of disruptor and JMH
- decrease number of iterations to speed up getting of result
- fix PI calculation in ForkJoin benchmarks
- add single thread benchmark
- minimize usage of float point operations in calculatePI function
- clean up of code
